### PR TITLE
add Reply-Code Alpha quest item linking

### DIFF
--- a/thatsmybis/link_tokens.sql
+++ b/thatsmybis/link_tokens.sql
@@ -1076,3 +1076,15 @@ UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE 
 UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 44577 LIMIT 1) as haxxorz), `parent_item_id` = 44577 WHERE `item_id` = 44662 AND `expansion_id` = 3; -- Life-Binder's Locket
 UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 44577 LIMIT 1) as haxxorz), `parent_item_id` = 44577 WHERE `item_id` = 44665 AND `expansion_id` = 3; -- Nexus War Champion Beads
 UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 44577 LIMIT 1) as haxxorz), `parent_item_id` = 44577 WHERE `item_id` = 44661 AND `expansion_id` = 3; -- Wyrmrest Necklace of Power
+-- Reply-Code Alpha 25 man
+UPDATE `items` SET `parent_id` = NULL, `parent_item_id` = NULL WHERE `item_id` = 46053 AND `expansion_id` = 3; -- Reply-Code Alpha 25 man
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46053 LIMIT 1) as haxxorz), `parent_item_id` = 46053 WHERE `item_id` = 45588 AND `expansion_id` = 3; -- Drape of the Skyborn
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46053 LIMIT 1) as haxxorz), `parent_item_id` = 46053 WHERE `item_id` = 45608 AND `expansion_id` = 3; -- Brann's Signet Ring
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46053 LIMIT 1) as haxxorz), `parent_item_id` = 46053 WHERE `item_id` = 45618 AND `expansion_id` = 3; -- Sunglimmer Cloak
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46053 LIMIT 1) as haxxorz), `parent_item_id` = 46053 WHERE `item_id` = 45614 AND `expansion_id` = 3; -- Starshine Circle
+-- Reply-Code Alpha 10 man
+UPDATE `items` SET `parent_id` = NULL, `parent_item_id` = NULL WHERE `item_id` = 46052 AND `expansion_id` = 3; -- Reply-Code Alpha 10 man
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46052 LIMIT 1) as haxxorz), `parent_item_id` = 46052 WHERE `item_id` = 46320 AND `expansion_id` = 3; -- Drape of the Skyherald
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46052 LIMIT 1) as haxxorz), `parent_item_id` = 46052 WHERE `item_id` = 46322 AND `expansion_id` = 3; -- Brann's Sealing Ring
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46052 LIMIT 1) as haxxorz), `parent_item_id` = 46052 WHERE `item_id` = 46321 AND `expansion_id` = 3; -- Sunglimmer Drape
+UPDATE `items` SET `parent_id` = (SELECT * FROM (SELECT `id` FROM `items` WHERE `item_id` = 46052 LIMIT 1) as haxxorz), `parent_item_id` = 46052 WHERE `item_id` = 46323 AND `expansion_id` = 3; -- Starshine Signet


### PR DESCRIPTION
Doesn't look like `Reply-Code Alpha` (quest item off Algalon) is linked to the quest rewards. I'm hoping this db update will take care of it. Not sure if there's something else somewhere that needs to be updated as well.